### PR TITLE
Falta de la dependencia subfinder en el archivo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ TODO : installation script
 #### httprobe
 ``GO111MODULE=on go get -u github.com/tomnomnom/httprobe``
 
+#### subfinder
+``GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder``
+
 ## How to install
 
 ```


### PR DESCRIPTION
Hola @pdelteil, estaba utilizando su herramienta y me percate de que hacia falta mencionar en su archivo README.md la dependencia `subfinder`.

Así que la agregue al archivo para facilitarle el proceso de instalación a los nuevos usuarios.

Saludos.