### PR TITLE
Corrección del comando de instalación de httprobe en el archivo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 TODO : installation script
 
+#### subfinder
+``GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder``
 
 #### httpx 
-
-
-`GO111MODULE=on go get -v github.com/projectdiscovery/httpx/cmd/httpx`
+``GO111MODULE=on go get -v github.com/projectdiscovery/httpx/cmd/httpx``
 
 #### dnsx 
 ``GO111MODULE=on go get -v github.com/projectdiscovery/dnsx/cmd/dnsx``
@@ -18,10 +18,7 @@ TODO : installation script
 ``GO111MODULE=on go get -u github.com/tomnomnom/assetfinder`` 
 
 #### httprobe
-``GO111MODULE=on go get -u github.com/tomnomnom/httprobe``
-
-#### subfinder
-``GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder``
+``go get -u github.com/tomnomnom/httprobe``
 
 ## How to install
 


### PR DESCRIPTION
Hola @pdelteil, estaba utilizando su herramienta y me percate de que había un error en el comando de instalación de la dependencia `httprobe` en su archivo README.md.

Así que arregle este comando en el archivo para facilitarle el proceso de instalación a los nuevos usuarios.

Saludos.